### PR TITLE
Add thread id logging

### DIFF
--- a/CDS.SQLiteLogging/Internal/LogWriter.cs
+++ b/CDS.SQLiteLogging/Internal/LogWriter.cs
@@ -20,9 +20,9 @@ class LogWriter
         // Predefined SQL INSERT command
         sqlInsert = $@"
             INSERT INTO {tableName} (
-                Category, EventId, EventName, Timestamp, Level, MessageTemplate, Properties, RenderedMessage, ExceptionJson, ScopesJson
+                Category, EventId, EventName, Timestamp, Level, ManagedThreadId, MessageTemplate, Properties, RenderedMessage, ExceptionJson, ScopesJson
             ) VALUES (
-                @Category, @EventId, @EventName, @Timestamp, @Level, @MessageTemplate, @Properties, @RenderedMessage, @ExceptionJson, @ScopesJson
+                @Category, @EventId, @EventName, @Timestamp, @Level, @ManagedThreadId, @MessageTemplate, @Properties, @RenderedMessage, @ExceptionJson, @ScopesJson
             );";
     }
 
@@ -111,6 +111,7 @@ class LogWriter
         cmd.Parameters.AddWithValue("@EventName", entry.EventName ?? (object)DBNull.Value);
         cmd.Parameters.AddWithValue("@Timestamp", entry.Timestamp.ToString("o"));
         cmd.Parameters.AddWithValue("@Level", entry.Level);
+        cmd.Parameters.AddWithValue("@ManagedThreadId", entry.ManagedThreadId);
         cmd.Parameters.AddWithValue("@MessageTemplate", entry.MessageTemplate ?? (object)DBNull.Value);
         cmd.Parameters.AddWithValue("@Properties", entry.SerializeMsgParams() ?? (object)DBNull.Value);
         cmd.Parameters.AddWithValue("@RenderedMessage", entry.RenderedMessage ?? (object)DBNull.Value);

--- a/CDS.SQLiteLogging/Internal/TableCreator.cs
+++ b/CDS.SQLiteLogging/Internal/TableCreator.cs
@@ -37,6 +37,7 @@ class TableCreator
             "EventName TEXT",
             "Timestamp TEXT",
             "Level INTEGER",
+            "ManagedThreadId INTEGER",
             "MessageTemplate TEXT",
             "Properties TEXT",
             "RenderedMessage TEXT",

--- a/CDS.SQLiteLogging/LogEntry.cs
+++ b/CDS.SQLiteLogging/LogEntry.cs
@@ -77,6 +77,11 @@ public class LogEntry
     public LogLevel Level { get; set; }
 
     /// <summary>
+    /// Gets or sets the managed thread identifier for the log entry.
+    /// </summary>
+    public int ManagedThreadId { get; set; }
+
+    /// <summary>
     /// Gets or sets the message of the log entry. If used in the context of structured logging, this should be a template.
     /// For example, "User {Username} logged in.". Use the MsgParams for the actual values.
     /// </summary>
@@ -112,6 +117,7 @@ public class LogEntry
     public LogEntry()
     {
         Timestamp = DateTimeOffset.Now;
+        ManagedThreadId = Environment.CurrentManagedThreadId;
     }
 
     /// <summary>
@@ -139,6 +145,8 @@ public class LogEntry
     {
         // Assign a unique LiveId for this log entry
         LiveId = nextLiveId++;
+
+        ManagedThreadId = Environment.CurrentManagedThreadId;
 
         Timestamp = timeStamp;
         Category = category;

--- a/CDS.SQLiteLogging/MEL/MELLogger.cs
+++ b/CDS.SQLiteLogging/MEL/MELLogger.cs
@@ -13,7 +13,7 @@ public class MELLogger : ILogger
     /// Version that will increment every time the database scheme is modified.
     /// This number can be used on the database file name to ensure compatibility.
     /// </summary>
-    public static int DBSchemaVersion { get; } = 8;
+    public static int DBSchemaVersion { get; } = 9;
 
 
     private readonly string categoryName;

--- a/CDS.SQLiteLogging/Reader.cs
+++ b/CDS.SQLiteLogging/Reader.cs
@@ -198,6 +198,7 @@ public class Reader : IDisposable
             EventName = reader.GetString(reader.GetOrdinal(nameof(LogEntry.EventName))),
             Timestamp = DateTimeOffset.Parse(reader.GetString(reader.GetOrdinal(nameof(LogEntry.Timestamp)))),
             Level = (LogLevel)reader.GetInt32(reader.GetOrdinal(nameof(LogEntry.Level))),
+            ManagedThreadId = reader.GetInt32(reader.GetOrdinal(nameof(LogEntry.ManagedThreadId))),
             MessageTemplate = reader.GetString(reader.GetOrdinal(nameof(LogEntry.MessageTemplate))),
             RenderedMessage = reader.GetString(reader.GetOrdinal(nameof(LogEntry.RenderedMessage))),
             ExceptionJson = reader.GetString(reader.GetOrdinal(nameof(LogEntry.ExceptionJson))),

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1",
+  "version": "2.0",
   "publicReleaseRefSpec": [ "^refs/heads/main$", "^refs/tags/v\\d+\\.\\d+\\.\\d+$" ],
   "cloudBuild": {
     "setVersionVariables": true


### PR DESCRIPTION
## Summary
- track Environment.CurrentManagedThreadId in LogEntry
- include `ManagedThreadId` in SQL schema and write operations
- update reader to populate thread id
- bump DB schema version
- bump package version to 2.0

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ac68f52a08324960b372cfb8573e2