### PR TITLE
Fix artifact path in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: test-results-${{ runner.os }}
-        path: ./test-results/**/*.trx
+        path: '**/test-results/**/*.trx'
 
     - name: Upload NuGet Packages (only on tag pushes)
       if: startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
## Summary
- update test results artifact path for GitHub Actions

## Testing
- `git push` *(fails: No configured push destination)*

------
https://chatgpt.com/codex/tasks/task_e_685ae2f09b388324aabb7d2be84d0e8d