### PR TITLE
Fix TRX generation: use native --report-trx for new MSTest runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,9 @@ jobs:
         dotnet test
         --no-build
         --configuration Release
-        --logger "trx;LogFileName=test-results.trx"
+        --
+        --report-trx
+        --report-trx-filename test-results.trx
         --results-directory ./test-results
 
     - name: Publish test results


### PR DESCRIPTION
The new MSTest runner (EnableMSTestRunner=true with TestingPlatformDotnetTestSupport=true) does not forward --logger "trx" through the dotnet test bridge. Pass --report-trx directly to the testing platform via -- separator so TRX files are actually generated.

https://claude.ai/code/session_015EM59erWUVGdAXjLuayj6L

## Description
Brief description of what this PR changes and why.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring / code quality

## Checklist
- [ ] Code follows the project's coding conventions
- [ ] Public API changes have XML documentation
- [ ] Tests added or updated to cover the change
- [ ] All existing tests pass locally
- [ ] `CHANGELOG` / commit message is descriptive

## Related Issues
Closes #
